### PR TITLE
Make KLibc FILE* operations work with cmoc with -nodefaultlibs

### DIFF
--- a/Source/Libs/KLibc/imath/clcommon.a
+++ b/Source/Libs/KLibc/imath/clcommon.a
@@ -4,6 +4,10 @@
 
  psect clcommon_a,0,0,1,0,0
 
+ vsect
+_flacc: rmb 8 floating point & longs accumlator
+ endsect
+
 _lbexit: tfr cc,a save carry
  puls x get ret adr
  stx 2,s overwrite ls word

--- a/Source/Libs/KLibc/imath/rpterr.a
+++ b/Source/Libs/KLibc/imath/rpterr.a
@@ -1,7 +1,7 @@
 
  psect rpterr_a,0,0,0,0,0
 
-_rpterr: std errno,y
+_rpterr: std _errno,y
  pshs y,b
  os9 F$ID
  puls y,b

--- a/Source/Libs/KLibc/lib.a/GNUmakefile
+++ b/Source/Libs/KLibc/lib.a/GNUmakefile
@@ -8,7 +8,7 @@ OFILES4 = system.o reverse.o strings.o strcmp.o strlen.o strncpy.o strncat.o \
 OFILES5 = stringsu.o strucmp.o strnucmp.o case.o strclr.o memccpy.o memchr.o \
           memcmp.o memcpy.o memset.o atol.o atoi.o iob_data.o chcodes.o
 OFILES6 = sleep.o setjmp.o strass.o realloc.o calloc.o memory.o rand.o
-OFILES7 = gs1.o gs2.o ss1.o ss2.o ss3.o
+OFILES7 = gs1.o gs2.o ss1.o ss2.o ss3.o MUL168.o
 
 OFILES = $(OFILES1) $(OFILES2) $(OFILES3) $(OFILES4) $(OFILES5) \
 	$(OFILES6) $(OFILES7)

--- a/Source/Libs/KLibc/lib.a/errmsg.a
+++ b/Source/Libs/KLibc/lib.a/errmsg.a
@@ -6,7 +6,7 @@ _errmsg:
  lbsr _prgname
  pshs d
  leau _2,pcr
- leax _iob+26,y
+ leax __iob+26,y
  pshs x,u
  lbsr fprintf
  leas 6,s
@@ -15,7 +15,7 @@ _errmsg:
  ldd 8,s
  pshs d,x,u
  ldu 12,s
- leax _iob+26,y
+ leax __iob+26,y
  pshs x,u
  lbsr fprintf
  leas 10,s

--- a/Source/Libs/KLibc/lib.a/fopen.a
+++ b/Source/Libs/KLibc/lib.a/fopen.a
@@ -5,17 +5,17 @@
 
 *  input:   d = pn
 *           x = *mode
-*           u = *_iob = fp
-*  output:  _iob allocated of necessary, iniz _flag in any case
+*           u = *__iob = fp
+*  output:  __iob allocated of necessary, iniz _flag in any case
 *            to _READ or _WRITE or both.  Stash path num in _fd.
-*            setbase will fill in the rest since _iob is static
+*            setbase will fill in the rest since __iob is static
 *            and all zeros
 
 setiob
  pshs d save path number
  stu -2,s check for fp
  bne setiob3 if already have one
- leau _iob,y
+ leau __iob,y
  lda #_NFILE
 setiob1 ldb _flag+1,u
  andb #_READ+_WRITE
@@ -24,7 +24,7 @@ setiob1 ldb _flag+1,u
  deca
  bne setiob1
  ldd #$c8 e$pthful
- std errno,y
+ std _errno,y
  clra
  clrb
  puls x,pc
@@ -127,7 +127,7 @@ openit7 ldd ,s
 openit8 cmpb #'d
  beq openit10
 openit9 ldd #$cb E$BMode
-erret std errno,y
+erret std _errno,y
  ldd #-1
  bra openit13
 

--- a/Source/Libs/KLibc/lib.a/getc.a
+++ b/Source/Libs/KLibc/lib.a/getc.a
@@ -74,14 +74,14 @@ fillbuf ldd _flag,u
  pshs u stack fp
  lbsr _setbase init iob
  leas 2,s
-fillbu2 leax _iob,y
+fillbu2 leax __iob,y
  pshs x
  cmpu ,s++
  bne fillbu3 if not stdin
  ldb _flag+1,u
  andb #_SCF
  beq fillbu3 if rbf
- leax _iob+13,y
+ leax __iob+13,y
  pshs x
  lbsr fflush flush std out if scf on std in
  leas 2,s

--- a/Source/Libs/KLibc/lib.a/gets.a
+++ b/Source/Libs/KLibc/lib.a/gets.a
@@ -14,7 +14,7 @@ gets: pshs u
  bra gets2
 
 gets1 stb ,u+
-gets2 leax _iob,y
+gets2 leax __iob,y
  pshs x
  lbsr getc
  leas 2,s

--- a/Source/Libs/KLibc/lib.a/gs1.a
+++ b/Source/Libs/KLibc/lib.a/gs1.a
@@ -18,7 +18,7 @@ common1 pshs U
  ldx #-1 return -1
  tfr X,U sign extend
  clra
- std errno,Y only an error sometimes
+ std _errno,Y only an error sometimes
 common2 stx _flacc,Y top half
  leax _flacc,Y need a pointer for lmove
  stu 2,X bottom half

--- a/Source/Libs/KLibc/lib.a/iob_data.a
+++ b/Source/Libs/KLibc/lib.a/iob_data.a
@@ -135,7 +135,7 @@ __iob EQU *
  fcb 0 _save
  fdb 0 _bufsiz
 
-  ENDSECTION
+ endsect
 
 * vsect
 * rmb 256 extra stack for file buffers

--- a/Source/Libs/KLibc/lib.a/iob_data.a
+++ b/Source/Libs/KLibc/lib.a/iob_data.a
@@ -1,10 +1,13 @@
- psect iob_data_a,0,0,1,0,0
-
  ifp1
  use ../defs/stdio.a
  endc
- vsect
-_iob: fdb 0 _ptr
+
+__iob EXPORT
+
+ SECTION rwdata
+
+__iob EQU *
+ fdb 0 _ptr
  fdb 0 _base
  fdb 0 _end
  fdb _READ _flag
@@ -132,7 +135,7 @@ _iob: fdb 0 _ptr
  fcb 0 _save
  fdb 0 _bufsiz
 
- endsect
+  ENDSECTION
 
 * vsect
 * rmb 256 extra stack for file buffers

--- a/Source/Libs/KLibc/lib.a/printf.a
+++ b/Source/Libs/KLibc/lib.a/printf.a
@@ -18,7 +18,7 @@ dectbl fdb 10000,1000,100,10
 
 printf: pshs u
  leau 6,s *expr
- leax _iob+13,y
+ leax __iob+13,y
  ldd 4,s *format
  bra printf1
 

--- a/Source/Libs/KLibc/lib.a/putc.a
+++ b/Source/Libs/KLibc/lib.a/putc.a
@@ -107,7 +107,7 @@ putw: pshs u
 *    closes all 16 files
 
 _tidyup: pshs u
- leax _iob,y point to array beg
+ leax __iob,y point to array beg
  ldb #_NFILE set up loop count
  pshs b
 

--- a/Source/Libs/KLibc/lib.a/puts.a
+++ b/Source/Libs/KLibc/lib.a/puts.a
@@ -12,7 +12,7 @@
 *        ->  *s (or c)
 
 puts: pshs u
- leax _iob+13,y stdout fp
+ leax __iob+13,y stdout fp
  ldd 4,s *s
  pshs d,x stack *s,fp
  bsr fputs

--- a/Source/Libs/KLibc/lib.a/stat.a
+++ b/Source/Libs/KLibc/lib.a/stat.a
@@ -76,7 +76,7 @@ cmpnam lda ,x
 clenup leas 33,s done w/ scratch area
  puls y,u,pc
 error clra
- std errno error code
+ std _errno error code
  ldd #-1 error flag
  bra clenup
 device fcs "@"

--- a/Source/Libs/KLibc/lib.c/GNUmakefile
+++ b/Source/Libs/KLibc/lib.c/GNUmakefile
@@ -1,19 +1,19 @@
 OFILES	= prof.o pwent.o getopt.o adump.o defdrive.o popen.o \
  asctime.o ctime.o localtime.o mktime.o isleap.o timevars.o
- 
+
 MISSING = omktime.o u2otime.o
 
-DFILES	= dbg.r getsp.r
+DFILES	= dbg.o getsp.o
 
 include ../cmoc.make
 
-cstuff.lib: $(OFILES)
+cstuff.l: $(OFILES)
 	lwar -c $@ $^
 
-dbg.lib: $(DFILES) ../defs/dbg.h
+dbg.l: $(DFILES) ../defs/dbg.h
 	lwar -c $@ $^
 
 clean:
-	-rm *.o *.s *.cp
+	-rm *.o *.s *.cp *.l
 
 $(OFILES): GNUmakefile $(DCCMOC) $(RMA2LW)

--- a/Source/Libs/KLibc/lib.c/dbg.c
+++ b/Source/Libs/KLibc/lib.c/dbg.c
@@ -124,9 +124,9 @@ _dumprof(){}
 
 /*page*/
 char  *h1 =
-{"addr   0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f  0 2 4 6 8 a c e \n"};
+"addr   0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f  0 2 4 6 8 a c e \n";
 char *h2 =
-{"----  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --  ----------------\n"};
+"----  -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --  ----------------\n";
 
 /*
 ** full screen display of 256 bytes from the prom
@@ -252,7 +252,7 @@ char  *s;
 ** converts integer 'n' into 'd' digits in string 's'.
 */
 
-static itoh(n, d, s)
+static char *itoh(n, d, s)
 int   n, d;
 char *s;
    {
@@ -297,7 +297,7 @@ char  *s;
    }
 
 
-static skipspace(s)
+static char *skipspace(s)
 char  *s;
    {
    while (*s == ' ')
@@ -311,7 +311,7 @@ static showsp()
    char  *p;
 
    strcpy(p = line, uspmsg);
-   p = itoh(sp, 4, p + strlen(p));
+   p = itoh((int)sp, 4, p + strlen(p));
    strcpy(p, "\n");
    writeln(2, line, strlen(line));
    }

--- a/Source/Libs/KLibc/sys.a/abort.a
+++ b/Source/Libs/KLibc/sys.a/abort.a
@@ -9,7 +9,7 @@ abort: pshs d,x,y,u
 
  cmpd #-1
  bne abort10
- ldd errno,y
+ ldd _errno,y
  os9 F$Exit
 
 abort10 leas 4,s

--- a/Source/Libs/KLibc/sys.a/lseek.a
+++ b/Source/Libs/KLibc/sys.a/lseek.a
@@ -20,7 +20,7 @@ lseek10 cmpd #1 from here?
  ldb #E$Seek
 
 lserr clra
- std errno,y
+ std _errno,y
  ldd #-1
  leax _flacc,y
  std 0,x

--- a/Source/Libs/KLibc/sys.a/sbrk.a
+++ b/Source/Libs/KLibc/sys.a/sbrk.a
@@ -4,7 +4,7 @@
  psect sbrk,0,0,6,0,0
 
 * sbrk(size)   get memory from system
-sbrk: ldd _memend,y get hi bound
+sbrk: ldd __memend,y get hi bound
  pshs d save it
  ldd 4,s get the size required
  cmpd _spare,y any spare left?
@@ -24,7 +24,7 @@ sbrk: ldd _memend,y get hi bound
  ldb #E$MemFul out of memory
  lbra _os9err return error
 
-sbrk10 std _memend,y save new memory address
+sbrk10 std __memend,y save new memory address
  addd _spare,y add in spare bytes
  subd 0,s less old base
  std _spare,y is new spare value
@@ -35,14 +35,14 @@ sbrk20 leas 2,s junk scratch
  pshs d
  subd 4,s less size
  std _spare,y updated value
- ldd _memend,y get hi bound
+ ldd __memend,y get hi bound
  subd ,s++ base of free memory
  pshs d save
 
  clra
  ldx 0,s
 sbrk30 sta ,x+ clear out the new memory
- cmpx _memend,y
+ cmpx __memend,y
  blo sbrk30
 
  puls d,pc

--- a/Source/Libs/KLibc/tmath/dser.a
+++ b/Source/Libs/KLibc/tmath/dser.a
@@ -118,7 +118,7 @@ _errz pshs b save error code
  clra
  cmpb #43 underflow?
  lbne _rpterr
- std errno,y
+ std _errno,y
  rts
 
 _mzer


### PR DESCRIPTION
- Reference the version of _errno in cmoc's crt.asm
- Reference the version of _iob defined in KLibc
- Make sure _iob entries get initialized (via SECTION rwdata)
- Other nits exposed with -nodefaultlibs

I have tested FILE *-related operations with stdin, stdout, and stderr as well as things opened with fopen.  I have _only_ tested this with cmoc, and thus have no idea if these changes will work with anything other than cmoc, lwasm, etc.